### PR TITLE
Update rust bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.26.8"
+tree-sitter-language = "0.1"
 
 [build-dependencies]
 cc = "1.2"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,14 +2,55 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(src_dir);
-    c_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
+    c_config.std("c11").include(src_dir);
+
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        let Ok(wasm_headers) = std::env::var("DEP_TREE_SITTER_LANGUAGE_WASM_HEADERS") else {
+            panic!("Environment variable DEP_TREE_SITTER_LANGUAGE_WASM_HEADERS must be set by the language crate");
+        };
+        let Ok(wasm_src) =
+            std::env::var("DEP_TREE_SITTER_LANGUAGE_WASM_SRC").map(std::path::PathBuf::from)
+        else {
+            panic!("Environment variable DEP_TREE_SITTER_LANGUAGE_WASM_SRC must be set by the language crate");
+        };
+
+        c_config.include(&wasm_headers);
+        c_config.files([
+            wasm_src.join("stdio.c"),
+            wasm_src.join("stdlib.c"),
+            wasm_src.join("string.c"),
+        ]);
+    }
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
-
-    c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+
+    let scanner_path = src_dir.join("scanner.c");
+    if scanner_path.exists() {
+        c_config.file(&scanner_path);
+        println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    }
+
+    c_config.compile("tree-sitter-qmldir");
+
+    println!("cargo:rustc-check-cfg=cfg(with_highlights_query)");
+    if !"queries/highlights.scm".is_empty() && std::path::Path::new("queries/highlights.scm").exists() {
+        println!("cargo:rustc-cfg=with_highlights_query");
+    }
+    println!("cargo:rustc-check-cfg=cfg(with_injections_query)");
+    if !"queries/injections.scm".is_empty() && std::path::Path::new("queries/injections.scm").exists() {
+        println!("cargo:rustc-cfg=with_injections_query");
+    }
+    println!("cargo:rustc-check-cfg=cfg(with_locals_query)");
+    if !"queries/locals.scm".is_empty() && std::path::Path::new("queries/locals.scm").exists() {
+        println!("cargo:rustc-cfg=with_locals_query");
+    }
+    println!("cargo:rustc-check-cfg=cfg(with_tags_query)");
+    if !"queries/tags.scm".is_empty() && std::path::Path::new("queries/tags.scm").exists() {
+        println!("cargo:rustc-cfg=with_tags_query");
+    }
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,51 +1,52 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright © 2023, Decodetalkers <ShootingStarDragons@protonmail.com>, Amaan Qureshi <amaanq12@gmail.com>
-// See the LICENSE file in this repo for license details.
-// ------------------------------------------------------------------------------------------------
-
-//! This crate provides Qmldir language support for the [tree-sitter][] parsing library.
+//! This crate provides Qmldir language support for the [tree-sitter] parsing library.
 //!
-//! Typically, you will use the [language][language func] function to add this language to a
-//! tree-sitter [Parser][], and then use the parser to parse some code:
+//! Typically, you will use the [`LANGUAGE`] constant to add this language to a
+//! tree-sitter [`Parser`], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = r#"
+//! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_qmldir::language()).expect("Error loading Qmldir grammar");
+//! let language = tree_sitter_qmldir::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Qmldir parser");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
-//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-//! [language func]: fn.language.html
-//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [`Parser`]: https://docs.rs/tree-sitter/0.26.8/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_qmldir() -> Language;
+    fn tree_sitter_qmldir() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_qmldir) };
+
+/// The content of the [`node-types.json`] file for this grammar.
 ///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_qmldir() }
-}
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers/6-static-node-types
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-/// The source of the Rust tree-sitter grammar description.
-pub const GRAMMAR: &str = include_str!("../../grammar.js");
-
-/// The syntax highlighting query for this language.
+#[cfg(with_highlights_query)]
+/// The syntax highlighting query for this grammar.
 pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 
-/// The injection query for this language.
+#[cfg(with_injections_query)]
+/// The language injection query for this grammar.
 pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
 
-/// The content of the [`node-types.json`][] file for this grammar.
-///
-/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
+#[cfg(with_locals_query)]
+/// The local variable query for this grammar.
+pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+
+#[cfg(with_tags_query)]
+/// The symbol tagging query for this grammar.
+pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -53,7 +54,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
-            .expect("Error loading Qmldir grammar");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Qmldir parser");
     }
 }


### PR DESCRIPTION
Hey!

Since there were a lot of comments [on this PR](https://github.com/tree-sitter-grammars/tree-sitter-qmldir/pull/7) updating all the bindings, I gave up and only updated the Rust bindings, as that's what I need.
I integrated it within ki and it works:
<img width="418" height="185" alt="image" src="https://github.com/user-attachments/assets/0a38d173-14f1-4ede-99cc-5d8a02bb60f1" />
