### PR TITLE
fix(zig): update bindings to 0.16.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ package-lock.json
 /node_modules
 /examples/*/
 /target
+.zig-cache/
+zig-cache/
+zig-out/
+zig-pkg/

--- a/build.zig
+++ b/build.zig
@@ -4,46 +4,51 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    var threaded: std.Io.Threaded = .init(b.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
     const shared = b.option(bool, "build-shared", "Build a shared library") orelse true;
     const reuse_alloc = b.option(bool, "reuse-allocator", "Reuse the library allocator") orelse false;
 
     const library_name = "tree-sitter-qmldir";
 
+    var grammar = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+        .pic = if (shared) true else null,
+    });
     const lib: *std.Build.Step.Compile = b.addLibrary(.{
         .name = library_name,
         .linkage = if (shared) .dynamic else .static,
-        .root_module = b.createModule(.{
-            .target = target,
-            .optimize = optimize,
-            .link_libc = true,
-            .pic = if (shared) true else null,
-        }),
+        .root_module = grammar,
     });
 
-    lib.addCSourceFile(.{
+    grammar.addCSourceFile(.{
         .file = b.path("src/parser.c"),
         .flags = &.{"-std=c11"},
     });
-    if (fileExists(b, "src/scanner.c")) {
-        lib.addCSourceFile(.{
+    if (fileExists(b, io, "src/scanner.c")) {
+        grammar.addCSourceFile(.{
             .file = b.path("src/scanner.c"),
             .flags = &.{"-std=c11"},
         });
     }
 
     if (reuse_alloc) {
-        lib.root_module.addCMacro("TREE_SITTER_REUSE_ALLOCATOR", "");
+        grammar.addCMacro("TREE_SITTER_REUSE_ALLOCATOR", "");
     }
     if (optimize == .Debug) {
-        lib.root_module.addCMacro("TREE_SITTER_DEBUG", "");
+        grammar.addCMacro("TREE_SITTER_DEBUG", "");
     }
 
-    lib.addIncludePath(b.path("src"));
+    grammar.addIncludePath(b.path("src"));
 
     b.installArtifact(lib);
     b.installFile("src/node-types.json", "node-types.json");
 
-    if (fileExists(b, "queries")) {
+    if (fileExists(b, io, "queries")) {
         b.installDirectory(.{
             .source_dir = b.path("queries"),
             .install_dir = .prefix,
@@ -69,16 +74,10 @@ pub fn build(b: *std.Build) !void {
     tests.root_module.addImport(library_name, module);
 
     // HACK: fetch tree-sitter dependency only when testing this module
-    if (b.pkg_hash.len == 0) {
-        var args = try std.process.argsWithAllocator(b.allocator);
-        defer args.deinit();
-        while (args.next()) |a| {
-            if (std.mem.eql(u8, a, "test")) {
-                const ts_dep = b.lazyDependency("tree_sitter", .{}) orelse continue;
-                tests.root_module.addImport("tree-sitter", ts_dep.module("tree-sitter"));
-                break;
-            }
-        }
+    if (b.option(bool, "test", "Fetch test dependencies") orelse false) {
+        const ts_dep = b.lazyDependency("tree_sitter", .{});
+        if (ts_dep) |dep|
+            tests.root_module.addImport("tree-sitter", dep.module("tree_sitter"));
     }
 
     const run_tests = b.addRunArtifact(tests);
@@ -86,8 +85,8 @@ pub fn build(b: *std.Build) !void {
     test_step.dependOn(&run_tests.step);
 }
 
-inline fn fileExists(b: *std.Build, filename: []const u8) bool {
+inline fn fileExists(b: *std.Build, io: std.Io, filename: []const u8) bool {
     const dir = b.build_root.handle;
-    dir.access(filename, .{}) catch return false;
+    dir.access(io, filename, .{}) catch return false;
     return true;
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .tree_sitter = .{
-            .url = "git+https://github.com/tree-sitter/zig-tree-sitter#b4b72c903e69998fc88e27e154a5e3cc9166551b",
-            .hash = "tree_sitter-0.25.0-8heIf51vAQConvVIgvm-9mVIbqh7yabZYqPXfOpS3YoG",
+            .url = "git+https://github.com/tree-sitter/zig-tree-sitter.git#b562510b5563dcf3b7fcac4a5fe9d60834c84667",
+            .hash = "tree_sitter-0.26.0-8heIf-vDAQDh0HhAAUVwVZFmLrwSKMZl5gRaVFqtas0W",
             .lazy = true,
         },
     },


### PR DESCRIPTION
This updates the Zig bindings to be compatible with zig 0.16.0

Updated `build.zig` to match [existing zig bindings](https://github.com/tree-sitter/tree-sitter-c/blob/b780e47fc780ddc8da13afa35a3f4ed5c157823d/build.zig)